### PR TITLE
Add rancher_setting data source

### DIFF
--- a/rancher/data_source_rancher_setting.go
+++ b/rancher/data_source_rancher_setting.go
@@ -1,0 +1,44 @@
+package rancher
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceRancherSetting() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRancherSettingRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"value": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceRancherSettingRead(d *schema.ResourceData, meta interface{}) error {
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Refreshing Rancher Setting: %s", name)
+
+	client, err := meta.(*Config).GlobalClient()
+	if err != nil {
+		return err
+	}
+
+	setting, err := client.Setting.ById(name)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(name)
+	d.Set("value", setting.Value)
+
+	return nil
+}

--- a/rancher/data_source_rancher_setting_test.go
+++ b/rancher/data_source_rancher_setting_test.go
@@ -1,0 +1,29 @@
+package rancher
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccRancherSettingDataSource_accessLog(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckRancherSettingDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.rancher_setting.access_log", "value", "/dev/null"),
+				),
+			},
+		},
+	})
+}
+
+// Testing owner parameter
+const testAccCheckRancherSettingDataSourceConfig = `
+data "rancher_setting" "access_log" {
+	name = "access.log"
+}
+`

--- a/rancher/provider.go
+++ b/rancher/provider.go
@@ -60,6 +60,10 @@ func Provider() terraform.ResourceProvider {
 			"rancher_stack":               resourceRancherStack(),
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"rancher_setting": dataSourceRancherSetting(),
+		},
+
 		ConfigureFunc: providerConfigure,
 	}
 }

--- a/website/docs/d/setting.html.markdown
+++ b/website/docs/d/setting.html.markdown
@@ -1,0 +1,27 @@
+---
+layout: "rancher"
+page_title: "Rancher: rancher_setting"
+sidebar_current: "docs-rancher-datasource-setting"
+description: |-
+  Get information on a Rancher setting.
+---
+
+# rancher\_setting
+
+Use this data source to retrieve information about a Rancher setting.
+
+## Example Usage
+
+```
+data "rancher_setting" "cattle.cattle.version" {
+  name = "cattle.cattle.version"
+}
+```
+
+## Argument Reference
+
+ * `name` - (Required) The setting name.
+
+## Attributes Reference
+
+ * `value` - the settting's value.

--- a/website/rancher.erb
+++ b/website/rancher.erb
@@ -10,6 +10,15 @@
           <a href="/docs/providers/rancher/index.html">Rancher Provider</a>
         </li>
 
+        <li<%= sidebar_current("docs-rancher-datasource") %>>
+          <a href="#">Data Sources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-rancher-datasource-setting") %>>
+              <a href="/docs/providers/rancher/d/setting.html">rancher_setting</a>
+            </li>
+          </ul>
+        </li>
+
         <li<%= sidebar_current("docs-rancher-resource") %>>
           <a href="#">Resources</a>
           <ul class="nav nav-visible">


### PR DESCRIPTION
# rancher\_setting

Use this data source to retrieve information about a Rancher setting.

## Example Usage

```
data "rancher_setting" "cattle.cattle.version" {
  name = "cattle.cattle.version"
}
```

## Argument Reference

 * `name` - (Required) The setting name.

## Attributes Reference

 * `value` - the settting's value.
