### PR TITLE
Add activating to pending states

### DIFF
--- a/rancher/resource_rancher_host.go
+++ b/rancher/resource_rancher_host.go
@@ -68,7 +68,7 @@ func resourceRancherHostCreate(d *schema.ResourceData, meta interface{}) error {
 	hostname := d.Get("hostname").(string)
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"active", "removed", "removing", "not found", "registering"},
+		Pending:    []string{"active", "removed", "removing", "not found", "registering", "activating"},
 		Target:     []string{"active", "disconnected"},
 		Refresh:    findHost(client, hostname),
 		Timeout:    10 * time.Minute,


### PR DESCRIPTION
I add this error once, so I guess this patch is required:
```
* rancher_host.rancher-node: Error waiting for host (ip-1-2-3-4.us-east-1.compute.internal) to be found: unexpected state 'activating', wanted target 'active, disconnected'. last error: %!s(<nil>)
```