### PR TITLE
rancher_environment: (fixes #33) fix member creation, orchestration update and testing errors

### DIFF
--- a/rancher/resource_rancher_environment.go
+++ b/rancher/resource_rancher_environment.go
@@ -46,12 +46,14 @@ func resourceRancherEnvironment() *schema.Resource {
 				ValidateFunc:  validation.StringInSlice([]string{"cattle", "kubernetes", "mesos", "swarm", "windows"}, true),
 				Computed:      true,
 				ConflictsWith: []string{"project_template_id"},
+				ForceNew:      true,
 			},
 			"project_template_id": &schema.Schema{
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"orchestration"},
+				ForceNew:      true,
 			},
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
@@ -129,7 +131,7 @@ func resourceRancherEnvironmentCreate(d *schema.ResourceData, meta interface{}) 
 	d.SetId(newEnv.Id)
 	log.Printf("[INFO] Environment ID: %s", d.Id())
 
-	return resourceRancherEnvironmentUpdate(d, meta)
+	return resourceRancherEnvironmentCreateOrUpdateProjectMembers(d, meta)
 }
 
 func resourceRancherEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
@@ -167,10 +169,11 @@ func resourceRancherEnvironmentRead(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		return err
 	}
-
 	members, _ := envClient.ProjectMember.List(NewListOpts())
-
-	d.Set("member", normalizeMembers(members.Data))
+	normalizedMembers := normalizeMembers(members.Data)
+	if len(normalizedMembers) > 0 {
+		d.Set("member", normalizedMembers)
+	}
 	return nil
 }
 
@@ -184,18 +187,10 @@ func resourceRancherEnvironmentUpdate(d *schema.ResourceData, meta interface{}) 
 
 	name := d.Get("name").(string)
 	description := d.Get("description").(string)
-	orchestration := d.Get("orchestration").(string)
-	projectTemplateID := d.Get("project_template_id").(string)
-
-	projectTemplateID, err = getProjectTemplateID(orchestration, projectTemplateID)
-	if err != nil {
-		return err
-	}
 
 	data := map[string]interface{}{
-		"name":                &name,
-		"description":         &description,
-		"project_template_id": &projectTemplateID,
+		"name":        &name,
+		"description": &description,
 	}
 
 	var newEnv rancherClient.Project
@@ -208,20 +203,7 @@ func resourceRancherEnvironmentUpdate(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	// Update members
-	envClient, err := meta.(*Config).EnvironmentClient(d.Id())
-	if err != nil {
-		return err
-	}
-	members := d.Get("member").(*schema.Set).List()
-	_, err = envClient.Project.ActionSetmembers(&newEnv, &rancherClient.SetProjectMembersInput{
-		Members: makeProjectMembers(members),
-	})
-	if err != nil {
-		return err
-	}
-
-	return resourceRancherEnvironmentRead(d, meta)
+	return resourceRancherEnvironmentCreateOrUpdateProjectMembers(d, meta)
 }
 
 func resourceRancherEnvironmentDelete(d *schema.ResourceData, meta interface{}) error {
@@ -260,6 +242,35 @@ func resourceRancherEnvironmentDelete(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId("")
 	return nil
+}
+
+func resourceRancherEnvironmentCreateOrUpdateProjectMembers(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*Config).GlobalClient()
+	if err != nil {
+		return err
+	}
+
+	env, err := client.Project.ById(d.Id())
+	if err != nil {
+		return err
+	}
+
+	// Create or Update members
+	envClient, err := meta.(*Config).EnvironmentClient(d.Id())
+	if err != nil {
+		return err
+	}
+	members := d.Get("member").(*schema.Set).List()
+	log.Printf("[INFO] Create or Update Project Members: %v", makeProjectMembers(members))
+	if members != nil && len(members) > 0 {
+		_, err = envClient.Project.ActionSetmembers(env, &rancherClient.SetProjectMembersInput{
+			Members: makeProjectMembers(members),
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return resourceRancherEnvironmentRead(d, meta)
 }
 
 func getProjectTemplateID(orchestration, templateID string) (string, error) {

--- a/rancher/resource_rancher_environment_test.go
+++ b/rancher/resource_rancher_environment_test.go
@@ -84,7 +84,7 @@ func TestAccRancherEnvironment_members(t *testing.T) {
 					testAccCheckRancherEnvironmentExists("rancher_environment.foo", &environment),
 					resource.TestCheckResourceAttr("rancher_environment.foo", "name", "foo2"),
 					resource.TestCheckResourceAttr("rancher_environment.foo", "description", "Terraform acc test group - updated"),
-					resource.TestCheckResourceAttr("rancher_environment.foo", "orchestration", "swarm"),
+					resource.TestCheckResourceAttr("rancher_environment.foo", "orchestration", "cattle"),
 					resource.TestCheckResourceAttr("rancher_environment.foo", "member.#", "1"),
 				),
 			},
@@ -213,8 +213,8 @@ resource "rancher_environment" "foo" {
 
 const testAccRancherEnvironmentMembersUpdateConfig = `
 resource "rancher_environment" "foo" {
-	name = "foo"
-	description = "Terraform acc test group"
+	name = "foo2"
+	description = "Terraform acc test group - updated"
 	orchestration = "cattle"
 
 	member {
@@ -222,6 +222,7 @@ resource "rancher_environment" "foo" {
 		external_id_type = "github_user"
 		role = "owner"
 	}
+}
 `
 
 const testAccRancherInvalidEnvironmentConfig = `

--- a/website/docs/r/environment.html.md
+++ b/website/docs/r/environment.html.md
@@ -39,8 +39,8 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the environment.
 * `description` - (Optional) An environment description.
-* `orchestration` - (Optional) Must be one of **cattle**, **swarm**, **mesos**, **windows** or **kubernetes**. This is a helper for setting the project_template_ids for the included Rancher templates. This will conflict with project_template_id setting.
-* `project_template_id` - (Optional) This can be any valid project template ID. If this is set, then orchestration can not be. 
+* `orchestration` - (Optional) Must be one of **cattle**, **swarm**, **mesos**, **windows** or **kubernetes**. This is a helper for setting the project_template_ids for the included Rancher templates. This will conflict with project_template_id setting. Changing this forces a new resource to be created.
+* `project_template_id` - (Optional) This can be any valid project template ID. If this is set, then orchestration can not be. Changing this forces a new resource to be created.
 * `member` - (Optional) Members to add to the environment.
 
 ### Member Parameters Reference


### PR DESCRIPTION
- Moved project member creation and update part to another method to enable calling it in both create and update
- Fixed some errors in test file
- Added orchestration and project_template_id Schemas ForceNew flag, because Update method in Rancher API v2 does not support updating these fields. So to be able to change orchestration (or project_template_id), old resource must be deleted first after that a new resource can be created.

```
$> go test -run TestAccRancherEnvironment_* -v
=== RUN   TestAccRancherEnvironment_importBasic
--- PASS: TestAccRancherEnvironment_importBasic (8.75s)
=== RUN   TestAccRancherEnvironment_basic
--- PASS: TestAccRancherEnvironment_basic (15.57s)
=== RUN   TestAccRancherEnvironment_disappears
--- PASS: TestAccRancherEnvironment_disappears (6.33s)
=== RUN   TestAccRancherEnvironment_members
--- PASS: TestAccRancherEnvironment_members (15.90s)
PASS
ok  	github.com/ouzklcn/terraform-provider-rancher/rancher	46.563s
```