### PR TITLE
Add rancher_certificate data source

### DIFF
--- a/rancher/data_source_rancher_certificate.go
+++ b/rancher/data_source_rancher_certificate.go
@@ -1,0 +1,116 @@
+package rancher
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	rancher "github.com/rancher/go-rancher/v2"
+)
+
+func dataSourceRancherCertificate() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRancherCertificateRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"environment_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"algorithm": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cert_fingerprint": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"expires_at": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"issued_at": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"issuer": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"key_size": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"serial_number": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"subject_alternative_names": &schema.Schema{
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"version": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceRancherCertificateRead(d *schema.ResourceData, meta interface{}) error {
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Refreshing Rancher Certificate: %s", name)
+
+	environmentId := d.Get("environment_id").(string)
+	client, err := meta.(*Config).EnvironmentClient(environmentId)
+	if err != nil {
+		return err
+	}
+
+	certs, err := client.Certificate.List(NewListOpts())
+	if err != nil {
+		return err
+	}
+
+	var certificate rancher.Certificate
+
+	for _, cert := range certs.Data {
+		if cert.Name == name {
+			certificate = cert
+		}
+	}
+	if certificate.Name == "" {
+		return fmt.Errorf("failed to find certificate %s", name)
+	}
+
+	d.SetId(certificate.Id)
+
+	d.Set("description", certificate.Description)
+	d.Set("name", certificate.Name)
+
+	// Computed values
+	d.Set("cn", certificate.CN)
+	d.Set("algorithm", certificate.Algorithm)
+	d.Set("cert_fingerprint", certificate.CertFingerprint)
+	d.Set("expires_at", certificate.ExpiresAt)
+	d.Set("issued_at", certificate.IssuedAt)
+	d.Set("issuer", certificate.Issuer)
+	d.Set("serial_number", certificate.SerialNumber)
+	d.Set("subject_alternative_names", certificate.SubjectAlternativeNames)
+	d.Set("version", certificate.Version)
+
+	return nil
+}

--- a/rancher/data_source_rancher_certificate_test.go
+++ b/rancher/data_source_rancher_certificate_test.go
@@ -1,0 +1,30 @@
+package rancher
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccRancherCertificateDataSource_foo(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckRancherCertificateDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.rancher_certificate.foo", "cn", "foo"),
+				),
+			},
+		},
+	})
+}
+
+// Testing owner parameter
+const testAccCheckRancherCertificateDataSourceConfig = `
+data "rancher_certificate" "foo" {
+	name = "foo"
+	environment_id = "1a5"
+}
+`

--- a/rancher/provider.go
+++ b/rancher/provider.go
@@ -62,7 +62,8 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"rancher_setting": dataSourceRancherSetting(),
+			"rancher_setting":     dataSourceRancherSetting(),
+			"rancher_certificate": dataSourceRancherCertificate(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/website/docs/d/certificate.html.markdown
+++ b/website/docs/d/certificate.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "rancher"
+page_title: "Rancher: rancher_certificate"
+sidebar_current: "docs-rancher-datasource-certificate"
+description: |-
+  Get information on a Rancher certificate.
+---
+
+# rancher\_certificate
+
+Use this data source to retrieve information about a Rancher certificate.
+
+## Example Usage
+
+```hcl
+data "rancher_certificate" "foo" {
+  name = "foo"
+  environment_id = "1a5"
+}
+```
+
+## Argument Reference
+
+ * `name` - (Required) The setting name.
+ * `environment_id` - (Required) The ID of the environment.
+
+## Attributes Reference
+
+* `id` - The ID of the resource.
+* `cn` - The certificate CN.
+* `algorithm` - The certificate algorithm.
+* `cert_fingerprint` - The certificate fingerprint.
+* `expires_at` - The certificate expiration date.
+* `issued_at` - The certificate creation date.
+* `issuer` - The certificate issuer.
+* `serial_number` - The certificate serial number.
+* `subject_alternative_names` - The list of certificate Subject Alternative Names.
+* `version` - The certificate version.


### PR DESCRIPTION
```hcl
data rancher_certificate "bar" {
  name = "foo"
  environment_id = "1a136639"
}
```

```shell
$ tf state show rancher_certificate.bar
id                          = 1c95
algorithm                   = SHA256WITHRSA
cert_fingerprint            = 1f:bb:ca:33:c4:63:04:d2:56:d0:e7:7e:7b:77:20:98:d0:6c:7e:01
cn                          = foo
description                 = my foo certificate bar
environment_id              = 1a136639
expires_at                  = Thu Mar 15 11:09:43 UTC 2018
issued_at                   = Wed Mar 15 11:09:43 UTC 2017
issuer                      = CN=foo,O=Internet Widgits Pty Ltd,ST=Some-State,C=FR
name                        = foo
serial_number               = 17919104905052083092
subject_alternative_names.# = 0
version                     = 1
```

