### PR TITLE
rancher_registry_credential: remove legacy email parameter

### DIFF
--- a/rancher/resource_rancher_registry_credential.go
+++ b/rancher/resource_rancher_registry_credential.go
@@ -39,8 +39,9 @@ func resourceRancherRegistryCredential() *schema.Resource {
 				ForceNew: true,
 			},
 			"email": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "The email parameter is not used anymore and will be removed in future versions of the provider.",
 			},
 			"public_value": &schema.Schema{
 				Type:     schema.TypeString,

--- a/rancher/resource_rancher_registry_credential_test.go
+++ b/rancher/resource_rancher_registry_credential_test.go
@@ -191,7 +191,6 @@ resource "rancher_registry_credential" "foo" {
 	name = "foo"
 	description = "registry credential test"
 	registry_id = "${rancher_registry.foo.id}"
-	email = "registry@credential.com"
 	public_value = "user"
 	secret_value = "pass"
 }
@@ -214,7 +213,6 @@ resource "rancher_registry_credential" "foo" {
 	name = "foo2"
 	description = "registry credential test - updated"
 	registry_id = "${rancher_registry.foo.id}"
-	email = "registry@credential.com"
 	public_value = "user2"
 	secret_value = "pass"
 }

--- a/website/docs/r/registry_credential.html.markdown
+++ b/website/docs/r/registry_credential.html.markdown
@@ -18,7 +18,6 @@ resource "rancher_registry_credential" "dockerhub" {
   name         = "dockerhub"
   description  = "DockerHub Registry Credential"
   registry_id  = "${rancher_registry.dockerhub.id}"
-  email        = "myself@company.com"
   public_value = "myself"
   secret_value = "mypass"
 }
@@ -31,7 +30,6 @@ The following arguments are supported:
 * `name` - (Required) The name of the registry credential.
 * `description` - (Optional) A registry credential description.
 * `registry_id` - (Required) The ID of the registry to create the credential for.
-* `email` - (Required) The email of the account.
 * `public_value` - (Required) The public value (user name) of the account.
 * `secret_value` - (Required) The secret value (password) of the account.
 


### PR DESCRIPTION
This parameter is not used anymore, since Rancher API v2 doesn't accept it. Fixes #56.