### PR TITLE
Don't check if api_url is provided

### DIFF
--- a/rancher/provider.go
+++ b/rancher/provider.go
@@ -114,10 +114,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		}
 	}
 
-	if apiURL == "" {
-		return &Config{}, fmt.Errorf("No api_url provided")
-	}
-
 	config := &Config{
 		APIURL:    apiURL,
 		AccessKey: accessKey,


### PR DESCRIPTION
This provider works "in-cluster" without setting any environment
variables. Setting `api_url` is not mandatory then.

Related to #76 