### PR TITLE
Add network policy support

### DIFF
--- a/rancher/data_source_rancher_certificate.go
+++ b/rancher/data_source_rancher_certificate.go
@@ -76,8 +76,8 @@ func dataSourceRancherCertificateRead(d *schema.ResourceData, meta interface{}) 
 	name := d.Get("name").(string)
 	log.Printf("[INFO] Refreshing Rancher Certificate: %s", name)
 
-	environmentId := d.Get("environment_id").(string)
-	client, err := meta.(*Config).EnvironmentClient(environmentId)
+	environmentID := d.Get("environment_id").(string)
+	client, err := meta.(*Config).EnvironmentClient(environmentID)
 	if err != nil {
 		return err
 	}

--- a/rancher/resource_rancher_registration_token.go
+++ b/rancher/resource_rancher_registration_token.go
@@ -133,7 +133,7 @@ func resourceRancherRegistrationTokenRead(d *schema.ResourceData, meta interface
 	}
 
 	regCommand := addHostLabels(regT.Command, d.Get("host_labels").(map[string]interface{}))
-	regCommand = addAgentIp(regCommand, d.Get("agent_ip").(string))
+	regCommand = addAgentIP(regCommand, d.Get("agent_ip").(string))
 	log.Printf("[INFO] RegistrationToken Name: %s", regT.Name)
 
 	d.Set("description", regT.Description)

--- a/rancher/util.go
+++ b/rancher/util.go
@@ -81,7 +81,7 @@ func addHostLabels(command string, labels map[string]interface{}) string {
 	return strings.Join(result, " ")
 }
 
-func addAgentIp(command string, ip string) string {
+func addAgentIP(command string, ip string) string {
 	result := []string{}
 
 	if ip == "" {


### PR DESCRIPTION
Implements: https://rancher.com/docs/rancher/v1.6/en/rancher-services/network-policy/

```terraform
resource "rancher_environment" "default" {
  name               = "default"
  orchestration  = "cattle"
  default_policy = "deny"

  policy = {
    action     = "allow"
    between = "com.rancher.foo"
  }
}
```