### PR TITLE
Avoid crashing when registry ID cannot be found

### DIFF
--- a/rancher/config.go
+++ b/rancher/config.go
@@ -1,6 +1,7 @@
 package rancher
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/rancher/go-rancher/catalog"
@@ -62,6 +63,9 @@ func (c *Config) RegistryClient(id string) (*rancherClient.RancherClient, error)
 	reg, err := client.Registry.ById(id)
 	if err != nil {
 		return nil, err
+	}
+	if reg == nil {
+		return nil, fmt.Errorf("Registry ID %v not found. Check your API key permissions.", id)
 	}
 
 	return c.EnvironmentClient(reg.AccountId)


### PR DESCRIPTION
When the API does not find the Registry by its ID (in particular when the user is not admin), it doesn't return an error but only a nil object, which causes a nil pointer further down.